### PR TITLE
fix(manifest): move the host URL to `host_permissions` key

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
     },
     "background": {},
     "host_permissions": [
-        "https://bigfrontend.dev/"
+        "https://bigfrontend.dev/*"
     ],
     "permissions": [
         "unlimitedStorage",

--- a/manifest.json
+++ b/manifest.json
@@ -15,8 +15,10 @@
         "default_popup": "popup.html"
     },
     "background": {},
+    "host_permissions": [
+        "https://bigfrontend.dev/"
+    ],
     "permissions": [
-        "https://bigfrontend.dev/*",
         "unlimitedStorage",
         "storage"
     ],


### PR DESCRIPTION
According to the [Manifest file format version 3](https://developer.chrome.com/docs/extensions/reference/manifest#popup-with-permissions) documentation, the URL should live under the `host_permissions` key instead of `permissions` one.

Moreover, the current `manifest.json` file has some errors.

## Before

<img width="404" alt="Screenshot 2023-12-07 at 17 04 23" src="https://github.com/vetrivelcsamy/bfe-dev-tracker/assets/6315466/b63252dd-c907-4a14-a119-289e3a376b35">

<img width="679" alt="Screenshot 2023-12-07 at 17 04 30" src="https://github.com/vetrivelcsamy/bfe-dev-tracker/assets/6315466/a31dc626-bcf0-4a0e-bcce-bcd6b8c04c01">

## After

<img width="405" alt="Screenshot 2023-12-07 at 17 05 12" src="https://github.com/vetrivelcsamy/bfe-dev-tracker/assets/6315466/397d511f-a571-42ca-9592-233d70320efb">

The extensions still work as expected:
<img width="500" alt="Screenshot 2023-12-07 at 17 23 20" src="https://github.com/vetrivelcsamy/bfe-dev-tracker/assets/6315466/ccd91fec-ad0e-4163-87fa-0d2e3c468f1a">


